### PR TITLE
Make rsync only run when in the correct folder

### DIFF
--- a/applyFixesAndOverride.sh
+++ b/applyFixesAndOverride.sh
@@ -13,8 +13,7 @@ sed -i 's/<Winsock.h>/<winsock.h>/' minorGems/network/unix/SocketPollUnix.cpp;
 
 popd
 
-cd override
-rsync -vr . ../..
+cd override && rsync -vr . ../..
 
 cd ..
 


### PR DESCRIPTION
I somehow had this script on the wrong folder and ran it by pure chance. It probably wont happen again, but here's the fix